### PR TITLE
Забыли добавить в исключения

### DIFF
--- a/lib/PayU.php
+++ b/lib/PayU.php
@@ -234,6 +234,7 @@ class PayU
             'LU_ENABLE_TOKEN',
             'LU_TOKEN_TYPE',
             'TESTORDER',
+            'LANGUAGE'
         );
 
         $hash = '';


### PR DESCRIPTION
В документации http://www.payu.ru/sites/new_russia/files/004_payu_live_update_-_ru_1.6_pnr.pdf 
сказано "Параметры TESTORDER и LANGUAGE не участвуют в формировании контрольной подписи. ".

А в документации не указанно что параметр DEBUG тоже не участвует в генерации контрольной суммы
